### PR TITLE
ci: run checks on push to main and validate all pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches:
       - main
+  push:
+    branches:
+      - main
 
 permissions:
   contents: read
@@ -21,7 +24,7 @@ jobs:
           node-version: '20'
 
       - name: Run HTML validation
-        run: npx html-validate index.html
+        run: npx html-validate *.html
 
   check-links:
     name: External Link Check
@@ -32,5 +35,5 @@ jobs:
       - name: Check external links with lychee
         uses: lycheeverse/lychee-action@v2.8.0
         with:
-          args: --no-progress index.html
+          args: --no-progress './*.html'
           fail: true

--- a/001.html
+++ b/001.html
@@ -142,9 +142,9 @@
         <span class="ctrl-val" id="re-display">—</span>
       </div>
       <div class="viz-modes">
-        <button class="viz-btn" data-mode="velocity">Speed</button>
-        <button class="viz-btn active" data-mode="vorticity">Vorticity</button>
-        <button class="viz-btn" data-mode="pressure">Pressure</button>
+        <button type="button" class="viz-btn" data-mode="velocity">Speed</button>
+        <button type="button" class="viz-btn active" data-mode="vorticity">Vorticity</button>
+        <button type="button" class="viz-btn" data-mode="pressure">Pressure</button>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## 概要

サイト健全性チェック(リスク #3)への対処。CIが実質機能していなかった2つの穴を塞ぎます。

## 変更内容

### `.github/workflows/ci.yml`
- **`push: branches: [main]` トリガーを追加** — develop → main の直接push運用でもCIが走るように。これまではPR経由でしかCIが実行されず、通常運用では一度も検証されないまま本番公開されていた
- **検証対象を全HTMLページに拡大** — html-validate / lychee とも `index.html` のみ → `*.html`(全6ページ+今後追加分も自動カバー)

### `001.html`
- viz-modeボタン3つに `type="button"` を追加(検証拡大で表面化する唯一のエラーを先回りで修正)

## 確認済み
- ローカルで `npx html-validate *.html` を実行し全ページクリーン
- このPR自体で新しいワークフローが全ページに対して実行されます

https://claude.ai/code/session_01KuhSrhMVVQqmxoHf4tAa4k

---
_Generated by [Claude Code](https://claude.ai/code/session_01KuhSrhMVVQqmxoHf4tAa4k)_