### PR TITLE
docs: add copyright notice to footer and README license section

### DIFF
--- a/001.html
+++ b/001.html
@@ -151,7 +151,7 @@
 </div>
 
 <footer class="footer">
-  Contact → <a href="https://x.com/mash3gt" target="_blank" rel="noopener noreferrer">X @mash3gt</a>
+  Contact → <a href="https://x.com/mash3gt" target="_blank" rel="noopener noreferrer">X @mash3gt</a> · © 2023–2026 mash3gt. All rights reserved.
 </footer>
 
 <script>

--- a/002.html
+++ b/002.html
@@ -118,7 +118,7 @@
 </div>
 
 <footer class="footer">
-  Contact → <a href="https://x.com/mash3gt" target="_blank" rel="noopener noreferrer">X @mash3gt</a>
+  Contact → <a href="https://x.com/mash3gt" target="_blank" rel="noopener noreferrer">X @mash3gt</a> · © 2023–2026 mash3gt. All rights reserved.
 </footer>
 
 <script>

--- a/003.html
+++ b/003.html
@@ -99,7 +99,7 @@
 </div>
 
 <footer class="footer">
-  Contact → <a href="https://x.com/mash3gt" target="_blank" rel="noopener noreferrer">X @mash3gt</a>
+  Contact → <a href="https://x.com/mash3gt" target="_blank" rel="noopener noreferrer">X @mash3gt</a> · © 2023–2026 mash3gt. All rights reserved.
 </footer>
 
 <script>

--- a/README.md
+++ b/README.md
@@ -26,3 +26,11 @@ Physics and engineering simulations presented as art — a personal museum built
 - No API keys, tokens, or personal data in commits
 - External links use `rel="noopener noreferrer"`
 - External scripts kept to a minimum
+
+## License
+
+© 2023–2026 mash3gt. All rights reserved.
+
+The works in this museum — code, simulations, images, and text — are published
+for viewing only. Reproduction, modification, or redistribution of any part of
+this repository is not permitted without prior written permission.

--- a/about.html
+++ b/about.html
@@ -145,7 +145,7 @@
 </div>
 
 <footer class="footer">
-  Contact → <a href="https://x.com/mash3gt" target="_blank" rel="noopener noreferrer">X @mash3gt</a>
+  Contact → <a href="https://x.com/mash3gt" target="_blank" rel="noopener noreferrer">X @mash3gt</a> · © 2023–2026 mash3gt. All rights reserved.
 </footer>
 
 </body>

--- a/concept.html
+++ b/concept.html
@@ -73,7 +73,7 @@
 </div>
 
 <footer class="footer">
-  Contact → <a href="https://x.com/mash3gt" target="_blank" rel="noopener noreferrer">X @mash3gt</a>
+  Contact → <a href="https://x.com/mash3gt" target="_blank" rel="noopener noreferrer">X @mash3gt</a> · © 2023–2026 mash3gt. All rights reserved.
 </footer>
 
 </body>

--- a/index.html
+++ b/index.html
@@ -118,7 +118,7 @@
 </div>
 
 <footer class="footer">
-  Contact → <a href="https://x.com/mash3gt" target="_blank" rel="noopener noreferrer">X @mash3gt</a>
+  Contact → <a href="https://x.com/mash3gt" target="_blank" rel="noopener noreferrer">X @mash3gt</a> · © 2023–2026 mash3gt. All rights reserved.
 </footer>
 
 </body>


### PR DESCRIPTION
## 概要

リスク #4(ライセンス表示なし)への対処・A案(全権利留保の明示)。

## 変更内容

- 全6ページの共有フッターに `© 2023–2026 mash3gt. All rights reserved.` を追記(既存の Contact 表記と同じ行・同じトーン)
- README に License セクションを追加(閲覧のみ可・複製/改変/再配布は要許可の旨を明記)

## 確認済み

- `npx html-validate *.html` 全ページクリーン
- フッターのデザイン(9px・中央寄せ・低コントラスト)はそのまま、視覚的な変化は最小限

https://claude.ai/code/session_01KuhSrhMVVQqmxoHf4tAa4k

---
_Generated by [Claude Code](https://claude.ai/code/session_01KuhSrhMVVQqmxoHf4tAa4k)_