### PR TITLE
ci: tolerate rate-limit responses in link check, update actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,10 @@ jobs:
     name: HTML Validation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '20'
 
@@ -30,10 +30,11 @@ jobs:
     name: External Link Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Check external links with lychee
         uses: lycheeverse/lychee-action@v2.8.0
         with:
-          args: --no-progress './*.html'
+          # 429 = rate-limited by the target site (e.g. Instagram), not a dead link
+          args: --no-progress --accept '100..=103,200..=299,429' './*.html'
           fail: true


### PR DESCRIPTION
## 概要

PR #8 マージ後のmain上のCIが、リンクチェックで赤になった件の対処。

## 原因

`instagram.com/mash3gt` が **429 Too Many Requests** を返したため。リンク切れではなく、Instagram側がチェッカーの自動アクセスを一時拒否しただけ(50リンク中49成功、失敗はこの1件のみ)。SNS系サイトでは日常的に起きるノイズです。

## 変更内容

- lychee に `--accept '100..=103,200..=299,429'` を追加 — レート制限(429)を「リンク生存」として扱い、ランダムな赤を防止
- `actions/checkout` / `actions/setup-node` を v4 → v5 に更新 — 2026/6/16からのNode 20強制切替の警告対処

https://claude.ai/code/session_01KuhSrhMVVQqmxoHf4tAa4k

---
_Generated by [Claude Code](https://claude.ai/code/session_01KuhSrhMVVQqmxoHf4tAa4k)_