### PR TITLE
docs: generalize About page job description, remove broken Signate link

### DIFF
--- a/about.html
+++ b/about.html
@@ -127,7 +127,6 @@
             <a href="https://github.com/mash3gt" target="_blank" rel="noopener noreferrer" class="ext-link">GitHub</a>
             <a href="https://atcoder.jp/users/ryu_boku" target="_blank" rel="noopener noreferrer" class="ext-link">AtCoder</a>
             <a href="https://www.kaggle.com/shiroguitar" target="_blank" rel="noopener noreferrer" class="ext-link">Kaggle</a>
-            <a href="https://user.competition.signate.jp/ja/account?tab=public" target="_blank" rel="noopener noreferrer" class="ext-link">Signate</a>
           </div>
         </div>
         <div class="links-group">

--- a/about.html
+++ b/about.html
@@ -104,7 +104,7 @@
         <ul class="info-list">
           <li>Data infrastructure development</li>
           <li>Test data analysis using that infrastructure</li>
-          <li>Simulator development for rocket engine projects</li>
+          <li>Simulator development for aerospace systems</li>
         </ul>
       </div>
     </div>


### PR DESCRIPTION
## 概要

リスク #6(Aboutページの名寄せ)への対処・B案+Signateリンクのバグ修正。

## 変更内容

### 職務記述の粒度を下げる(B案)
- `Simulator development for rocket engine projects` → `Simulator development for aerospace systems`
- 勤務先をほぼ特定できる記述を業界レベルの粒度に変更

### Signateリンクの削除
- リンク先が公開プロフィールではなく本人のアカウント設定ページ(`user.competition.signate.jp/ja/account?tab=public`)だったため、訪問者にはログイン画面が表示されていた
- 公開プロフィールURLが用意できるまで削除

## 確認済み
- `html-validate` クリーン

https://claude.ai/code/session_01KuhSrhMVVQqmxoHf4tAa4k

---
_Generated by [Claude Code](https://claude.ai/code/session_01KuhSrhMVVQqmxoHf4tAa4k)_