### PR TITLE
ci: resolve root-relative links and accept SNS bot-blocking in link check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
       - name: Check external links with lychee
         uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
         with:
-          # 429 = rate-limited by the target site (e.g. Instagram), not a dead link
-          args: --no-progress --accept '100..=103,200..=299,429' './*.html'
+          # 403/429 = bot-blocking / rate-limiting by SNS sites (X, Instagram), not dead links
+          # --root-dir resolves root-relative paths used by 404.html
+          args: --no-progress --accept '100..=103,200..=299,403,429' --root-dir ${{ github.workspace }} './*.html'
           fail: true


### PR DESCRIPTION
## 概要

PR #11 マージ後にmain上のリンクチェックが赤になった件の修正。

## 原因

404.html はどの階層のURLでも配信されるためルート相対パス(`/index.html` 等)を使っていますが、lychee にローカルファイル検査時の基準ディレクトリ(`--root-dir`)を渡しておらず、パスを解決できずエラーになっていました。**本番サイトのリンク自体は正常です**(CI設定の不足のみ)。

## 変更内容

- `--root-dir ${{ github.workspace }}` を追加 — ルート相対パスを解決可能に
- `--accept` に **403** を追加 — X(Twitter)はデータセンターIPからのアクセスをランダムに拒否するため、Instagramの429と同様「ボット拒否≠リンク切れ」として扱う

## 確認済み

ローカルで同一引数のlychee 0.20.1を実行: **48リンク中48 OK・エラー0**

https://claude.ai/code/session_01KuhSrhMVVQqmxoHf4tAa4k

---
_Generated by [Claude Code](https://claude.ai/code/session_01KuhSrhMVVQqmxoHf4tAa4k)_